### PR TITLE
Fix for NextJS

### DIFF
--- a/src/reactHandler.js
+++ b/src/reactHandler.js
@@ -70,7 +70,7 @@ exports.react = (subject, component, reactOpts = {}) => {
             if (getReactRoot(reactOpts.root) !== undefined) {
               elements = window.resq.resq$$(
                 component,
-                document.querySelector(getReactRoot(reactOpts.root))
+                cy.state('window').document.querySelector(getReactRoot(reactOpts.root))
               );
             } else {
               elements = window.resq.resq$$(component);
@@ -214,7 +214,7 @@ exports.getReact = (subject, component, reactOpts = {}) => {
           if (getReactRoot(reactOpts.root) !== undefined) {
             elements = window.resq.resq$$(
               component,
-              document.querySelector(getReactRoot(reactOpts.root))
+              cy.state('window').document.querySelector(getReactRoot(reactOpts.root))
             );
           } else {
             elements = window.resq.resq$$(component);


### PR DESCRIPTION
Fix `reactOpts.root` code path that attempted to get the React root element from the Cypress window document, rather than the page being tested.